### PR TITLE
Added migration number checking for update

### DIFF
--- a/Nestor/Nestor.cs
+++ b/Nestor/Nestor.cs
@@ -64,7 +64,8 @@ namespace Nestor
 						if (dbNests.Exists(x => x.Id == silphNest.Id))
 						{
 							var dbNest = dbNests.Find(x => x.Id == silphNest.Id);
-							if (silphNest.PokemonId != dbNest.PokemonId)
+							if (silphNest.PokemonId != dbNest.PokemonId ||
+								dbNest.LastMigration != _globalSettings.MigrationNumber)
 							{
 								var nest = AttachPokemonEntity(dbNest, silphNest.PokemonId);
 								var isUpdate = dbNest.LastMigration == _globalSettings.MigrationNumber;


### PR DESCRIPTION
In some cases Pokemon can remain in the nest after migration (e.g. 'small' migration during new pokemons release).

IMHO, in this case bot should send message to channel and update nest info in db (with new migration number).